### PR TITLE
Delete error file for new conversions

### DIFF
--- a/coverchecker.rb
+++ b/coverchecker.rb
@@ -80,7 +80,7 @@ end
 if files.include?("#{cover}")
 	test_missing_cover = "pass: I found a cover for this book."
 else
-	test_missing_img = "FAIL: The cover file is missing."
+	test_missing_cover = "FAIL: The cover file is missing."
 end
 
 # Printing the test results to the log file

--- a/coverchecker.rb
+++ b/coverchecker.rb
@@ -59,6 +59,7 @@ files = Dir.entries("#{coverdir}")
 
 # If a cover_error file exists, delete it
 cover_error = File.join(Bkmkr::Project.working_dir, "done", "pisbn", "COVER_ERROR.txt")
+puts cover_error
 if File.file?(cover_error)
 	FileUtils.rm(cover_error)
 end

--- a/coverchecker.rb
+++ b/coverchecker.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 require_relative '..\\bookmaker\\header.rb'
 
 # --------------------HTML FILE DATA START--------------------
@@ -54,6 +56,12 @@ cover = "#{pisbn}_FC.jpg"
 
 # An array listing all files in the submission dir
 files = Dir.entries("#{coverdir}")
+
+# If a cover_error file exists, delete it
+cover_error = File.join(Bkmkr::Project.working_dir, "done", "pisbn", "COVER_ERROR.txt")
+if File.file?(cover_error)
+	FileUtils.rm(cover_error)
+end
 
 # checks to see if cover is in the submission dir
 # if yes, copies cover to archival location and deletes from submission dir

--- a/coverchecker.rb
+++ b/coverchecker.rb
@@ -59,7 +59,6 @@ files = Dir.entries("#{coverdir}")
 
 # If a cover_error file exists, delete it
 cover_error = "#{Bkmkr::Project.working_dir}\\done\\#{pisbn}\\COVER_ERROR.txt"
-puts cover_error
 if File.file?(cover_error)
 	FileUtils.rm(cover_error)
 end

--- a/coverchecker.rb
+++ b/coverchecker.rb
@@ -58,7 +58,7 @@ cover = "#{pisbn}_FC.jpg"
 files = Dir.entries("#{coverdir}")
 
 # If a cover_error file exists, delete it
-cover_error = File.join(Bkmkr::Project.working_dir, "done", "pisbn", "COVER_ERROR.txt")
+cover_error = "#{Bkmkr::Project.working_dir}\\done\\pisbn\\COVER_ERROR.txt"
 puts cover_error
 if File.file?(cover_error)
 	FileUtils.rm(cover_error)

--- a/coverchecker.rb
+++ b/coverchecker.rb
@@ -73,3 +73,18 @@ else
 		output.write "There is no cover image for this title. Download the cover image from Biblio and place it in the submitted_images folder, then re-submit the manuscript for conversion; cover images must be named ISBN_FC.jpg."
 	end
 end
+
+# TESTING
+
+# Count how many images are referenced in the book
+if files.include?("#{cover}")
+	test_missing_cover = "pass: I found a cover for this book."
+else
+	test_missing_img = "FAIL: The cover file is missing."
+end
+
+# Printing the test results to the log file
+File.open("#{Bkmkr::Dir.log_dir}\\#{Bkmkr::Project.filename}.txt", 'a+') do |f|
+	f.puts "----- COVERCHECKER PROCESSES"
+	f.puts "#{test_missing_cover}"
+end

--- a/coverchecker.rb
+++ b/coverchecker.rb
@@ -58,7 +58,7 @@ cover = "#{pisbn}_FC.jpg"
 files = Dir.entries("#{coverdir}")
 
 # If a cover_error file exists, delete it
-cover_error = "#{Bkmkr::Project.working_dir}\\done\\pisbn\\COVER_ERROR.txt"
+cover_error = "#{Bkmkr::Project.working_dir}\\done\\#{pisbn}\\COVER_ERROR.txt"
 puts cover_error
 if File.file?(cover_error)
 	FileUtils.rm(cover_error)


### PR DESCRIPTION
If a done folder exists for a particular title (because of previous conversions), and a cover_error file exists from a past conversion, delete the error file before checking for the cover during the new conversion. Fixes #8 .